### PR TITLE
feat: keep body attributes to support theme, etc

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1465,6 +1465,32 @@ describe("Diff test", () => {
       expect(mutations).toEqual([]);
     });
 
+    it("should change the content of the BODY but keep the old attributes (theme, etc)", async () => {
+      const [newHTML] = await testDiff({
+        oldHTMLString: `
+        <html>
+          <head></head>
+          <body data-theme="dark">
+            <div>foo</div>
+          </body>
+        </html>
+      `,
+        newHTMLStringChunks: [
+          "<html><head></head><body><div>bar</div></body></html>",
+        ],
+      });
+      expect(newHTML).toBe(
+        normalize(`
+      <html>
+        <head></head>
+        <body data-theme="dark">
+          <div>bar</div>
+        </body>
+      </html>
+    `),
+      );
+    });
+
     it("should options.shouldIgnoreNode work", async () => {
       const [newHTML] = await testDiff({
         oldHTMLString: `
@@ -1576,11 +1602,11 @@ describe("Diff test", () => {
 
         const forEachStreamNode = useForEeachStreamNode
           ? (node: Node) => {
-            streamNodes.push({
-              nodeName: node.nodeName,
-              nodeValue: node.nodeValue,
-            } as Node);
-          }
+              streamNodes.push({
+                nodeName: node.nodeName,
+                nodeValue: node.nodeValue,
+              } as Node);
+            }
           : undefined;
 
         await diff(document.documentElement!, reader, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,10 +62,12 @@ async function updateNode(oldNode: Node, newNode: Node, walker: Walker) {
 
     walker[APPLY_TRANSITION](() => {
       if (oldNode.nodeName === newNode.nodeName) {
-        setAttributes(
-          (oldNode as Element).attributes,
-          (newNode as Element).attributes,
-        );
+        if (newNode.nodeName !== "BODY") {
+          setAttributes(
+            (oldNode as Element).attributes,
+            (newNode as Element).attributes,
+          );
+        }
       } else {
         const clonedNewNode = newNode.cloneNode();
         while (oldNode.firstChild)


### PR DESCRIPTION
Fixes https://github.com/aralroca/diff-dom-streaming/issues/11

During diffing we usually want to update all the content, but many times we make changes in runtime to decide how this content is displayed: theme, font, etc. Here we have a strong opinion about it and the diffing is going to be applied to all the HTML except the attributes of the BODY tag. So you can put class="dark" or data-attributes that during the diffing this part will be maintained and not crushed during navigation.

This being able to add themes, accessibility settings, etc. and be maintained during SPA navigation, example of usage:

![dark-mode](https://github.com/user-attachments/assets/64e72994-e34c-45e6-9466-a10aa10a5874)
