### PR TITLE
fix: re-implement streaming chunk process

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 The Diff DOM (Document Object Model) algorithm is used to compare two versions of the DOM, such as before and after an update on a web page. It aims to efficiently identify the changes between both DOMs, minimizing the number of manipulations required to update the user interface.
 
-The Diff DOM Streaming library extends the traditional Diff DOM algorithm by introducing support for comparing a DOM node with a streaming reader. This enables the library to process the changes incrementally as they occur during the diff process.
+The Diff DOM Streaming library extends the traditional Diff DOM algorithm by introducing support for comparing a DOM node with a stream. This enables the library to process the changes incrementally as they occur during the diff process.
 
 For more info, read this:
 
@@ -73,15 +73,15 @@ import diff from "https://unpkg.com/diff-dom-streaming@latest";
 ```ts
 const res = await fetch(/* some url */);
 
-// Diff between the current document and the reader:
-await diff(document, res.body.getReader());
+// Diff between the current document and the stream:
+await diff(document, res.body);
 ```
 
 ## API
 
-`diff(oldNode: Node, reader: ReadableStreamDefaultReader, options?: Options)`
+`diff(oldNode: Node, stream: ReadableStream<Uint8Array>, options?: Options): Promise<void>`
 
-This function performs a diffing operation between the `oldNode` and the DOM tree streamed through `reader`. It applies the necessary changes to update the `oldNode` accordingly. An optional `options` that include:
+This function performs a diffing operation between the `oldNode` and the DOM tree from a stream. It applies the necessary changes to update the `oldNode` accordingly. An optional `options` that include:
 
 ```ts
 type Options = {
@@ -115,7 +115,7 @@ The `diff-dom-streaming` library takes into account the `key` attribute for thes
 You can activate the View Transition API updating the DOM with this property:
 
 ```diff
-await diff(document, res.body.getReader(), {
+await diff(document, res.body, {
 + transition: true
 })
 ```
@@ -130,7 +130,7 @@ Many times it will make more sense to use a complete transition instead of incre
 
 ```diff
 + document.startViewTransition(async () => {
-await diff(document, res.body.getReader(), {
+await diff(document, res.body, {
 -  transition: true,
 });
 +});

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export default function diff(
   oldNode: Node,
-  reader: ReadableStreamDefaultReader,
+  stream: ReadableStream,
   options?: Options,
 ): Promise<void>;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -103,8 +103,7 @@ describe("Diff test", () => {
 
     it("should error with invalid arguments", async () => {
       const res = new Response('<div id="test">hello world</div>');
-      const reader = res.body!.getReader();
-      expect(() => diff("hello world" as any, reader)).toThrow(Error);
+      expect(() => diff("hello world" as any, res.body!)).toThrow(Error);
     });
 
     it("should not do any DOM modification", async () => {
@@ -1678,7 +1677,6 @@ describe("Diff test", () => {
           },
         });
         const allMutations: any[] = [];
-        const reader = readable.getReader();
         const observer = new MutationObserver((mutations) => {
           allMutations.push(
             ...mutations.map((mutation, mutationIndex) => ({
@@ -1726,7 +1724,7 @@ describe("Diff test", () => {
             }
           : undefined;
 
-        await diff(document.documentElement!, reader, {
+        await diff(document.documentElement!, readable, {
           onNextNode: forEachStreamNode,
           transition: transition as boolean,
           shouldIgnoreNode(node: Node | null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const APPLY_TRANSITION = 0;
 const FIRST_CHILD = 1;
 const NEXT_SIBLING = 2;
 const IS_LAST_NODE_OF_CHUNK = 3;
+const SPECIAL_TAGS = new Set(["HTML", "HEAD", "BODY"]);
 const wait = () => new Promise((resolve) => requestAnimationFrame(resolve));
 
 export default async function diff(
@@ -270,8 +271,13 @@ async function htmlStreamWalker(
   }
 
   function isLastNodeOfChunk(node: Node) {
-    if (!streamInProgress) return false;
-    if (node.nextSibling) return false;
+    if (!node || !streamInProgress || node.nextSibling) {
+      return false;
+    }
+
+    if (SPECIAL_TAGS.has(node.nodeName)) {
+      return !doc.body?.hasChildNodes?.();
+    }
 
     let parent = node.parentElement;
 
@@ -280,7 +286,7 @@ async function htmlStreamWalker(
       parent = parent.parentElement;
     }
 
-    return true;
+    return streamInProgress;
   }
 
   return {


### PR DESCRIPTION
Fixes https://github.com/aralroca/diff-dom-streaming/issues/13
Related https://github.com/brisa-build/brisa/issues/363 

CC: @AlbertSabate

This allows to use `TextDecoderStream` instead of `TextDecoder`.

It is a breaking change, now you have to pass `res.body` instead of `res.body.getReader()`.