### PR TITLE
fix: diff WC respecting internal DOM modifications

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aralroca/diff-dom-streaming",
-  "version": "0.6.1",
+  "version": "0.6.4",
   "exports": {
     ".": "./src/index.ts",
     "./types": "./index.d.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diff-dom-streaming",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "bugs": "https://github.com/aralroca/diff-dom-streaming/issues",
   "description": "Diff DOM algorithm with streaming. Gets all modifications, insertions and removals between a DOM fragment and a stream HTML reader.",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,10 +183,6 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
       walker[APPLY_TRANSITION](() => oldParent.appendChild(insertedNode!));
     }
 
-    if (insertedNode?.nodeType === ELEMENT_TYPE) {
-      await updateNode(insertedNode, newNode, walker);
-    }
-
     newNode = (await walker[NEXT_SIBLING](newNode)) as ChildNode;
 
     // If we didn't insert a node this means we are updating an existing one, so we


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/611

The problem that happened is that when doing diffing of the WC made 2 steps, first, it made an insert (L176), and after adding the node, it entered in line 188 and made a diffing with the `newNode` when the `insertedNode` was already a clone of the new one, but of course, the new one did not have the internal change of the DOM modified by the WC (`this.setAttribute`), then it is as if it had not been applied. 

https://github.com/aralroca/diff-dom-streaming/blob/0169dc1c9315099f340f7d60599e9fecf201eaca/src/index.ts#L173-L188

Example of WC:

```ts
class TestWC extends HTMLElement {
  connectedCallback() {
    this.setAttribute("data-connected", "true");
  }
}
customElements.define("test-wc", TestWC);
```

This PR fix the removal of `data-connected` in this extra unnecessary step.

Removing this code, all the tests continue passing and it solves the new tests that I have added. 

CC: @AlbertSabate