### PR TITLE
fix: stream the body progressively past an open last node, and reject instead of hanging on stream errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@aralroca/diff-dom-streaming",
-  "version": "0.6.6",
+  "version": "0.6.8",
   "exports": {
     ".": "./src/index.ts",
     "./types": "./index.d.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diff-dom-streaming",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "bugs": "https://github.com/aralroca/diff-dom-streaming/issues",
   "description": "Diff DOM algorithm with streaming. Gets all modifications, insertions and removals between a DOM fragment and a stream HTML reader.",
   "keywords": [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1899,12 +1899,38 @@ describe("Diff test", () => {
       // Executed exactly once (on initial page load), not again after diffing.
       expect(count).toBe(1);
     });
+
+    it("should reject the diff when the stream errors after a chunk instead of hanging the walker", async () => {
+      await expect(
+        testDiff({
+          oldHTMLString: `
+        <div>foo</div>
+      `,
+          newHTMLStringChunks: ["<div>bar</div>"],
+          errorStreamMessage: "network dead",
+          slowChunks: true,
+        }),
+      ).rejects.toThrow("network dead");
+    });
+
+    it("should reject the diff when the stream errors before any chunk", async () => {
+      await expect(
+        testDiff({
+          oldHTMLString: `
+        <div>foo</div>
+      `,
+          newHTMLStringChunks: [],
+          errorStreamMessage: "network dead",
+        }),
+      ).rejects.toThrow("network dead");
+    });
   });
 
   async function testDiff({
     oldHTMLString,
     newHTMLStringChunks = [],
     newHTMLByteChunks,
+    errorStreamMessage,
     useForEeachStreamNode = false,
     slowChunks = false,
     transition = false,
@@ -1918,6 +1944,9 @@ describe("Diff test", () => {
     // boundaries that split multi-byte characters, which cannot be expressed
     // as JS strings.
     newHTMLByteChunks?: number[][];
+    // When set, the stream errors with this message after emitting all chunks
+    // instead of closing (simulates an aborted fetch / dead network).
+    errorStreamMessage?: string;
     useForEeachStreamNode?: boolean;
     slowChunks?: boolean;
     transition?: boolean;
@@ -1931,6 +1960,7 @@ describe("Diff test", () => {
         diffCode,
         newHTMLStringChunks,
         newHTMLByteChunks,
+        errorStreamMessage,
         useForEeachStreamNode,
         slowChunks,
         transition,
@@ -1953,7 +1983,15 @@ describe("Diff test", () => {
                   : encoder.encode(chunk as string),
               );
             }
-            controller.close();
+            if (errorStreamMessage) {
+              // Let the already-enqueued chunks be consumed by the walker
+              // first, so the error lands while it awaits the next chunk.
+              if (slowChunks)
+                await new Promise((resolve) => setTimeout(resolve, 100));
+              controller.error(new Error(errorStreamMessage as string));
+            } else {
+              controller.close();
+            }
           },
         });
         const allMutations: any[] = [];
@@ -2033,6 +2071,7 @@ describe("Diff test", () => {
         diffCode,
         newHTMLStringChunks,
         newHTMLByteChunks,
+        errorStreamMessage,
         useForEeachStreamNode,
         slowChunks,
         transition,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1765,11 +1765,146 @@ describe("Diff test", () => {
       `),
       );
     });
+
+    it("should diff correctly when tag and attribute names are split across chunks", async () => {
+      const [newHTML] = await testDiff({
+        oldHTMLString: `
+        <div class="x">adios</div>
+      `,
+        newHTMLStringChunks: ["<di", "v cla", 'ss="a">hola</d', "iv>"],
+        slowChunks: true,
+      });
+
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div class="a">hola</div>
+          </body>
+        </html>
+      `),
+      );
+    });
+
+    it("should diff correctly when an attribute value is split across chunks", async () => {
+      const [newHTML] = await testDiff({
+        oldHTMLString: `
+        <div class="x">x</div>
+      `,
+        newHTMLStringChunks: ['<div class="a', 'b">x</div>'],
+        slowChunks: true,
+      });
+
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div class="ab">x</div>
+          </body>
+        </html>
+      `),
+      );
+    });
+
+    it("should decode multi-byte UTF-8 characters split across chunk boundaries", async () => {
+      const encoded = Array.from(
+        new TextEncoder().encode("<div>mañana 🚀</div>"),
+      );
+
+      // "ñ" is 2 bytes starting at index 7 → cutting at 8 splits it in half.
+      // "🚀" is 4 bytes starting at index 13 → cutting at 16 splits it apart.
+      expect(encoded.slice(7, 9)).toEqual([0xc3, 0xb1]);
+      expect(encoded.slice(13, 17)).toEqual([0xf0, 0x9f, 0x9a, 0x80]);
+
+      const [newHTML] = await testDiff({
+        oldHTMLString: `
+        <div>old</div>
+      `,
+        newHTMLByteChunks: [
+          encoded.slice(0, 8),
+          encoded.slice(8, 16),
+          encoded.slice(16),
+        ],
+        slowChunks: true,
+      });
+
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div>mañana 🚀</div>
+          </body>
+        </html>
+      `),
+      );
+    });
+
+    // Pins the CURRENT behavior: new <script> elements are parsed inside an
+    // inert document (createHTMLDocument + doc.write), which marks them as
+    // "already started"; cloneNode copies that flag, so inserting the clone
+    // into the live document does NOT execute it.
+    it("should insert a NEW streamed inline <script> without executing it (pins current behavior)", async () => {
+      const [newHTML] = await testDiff({
+        oldHTMLString: `
+        <div>foo</div>
+      `,
+        newHTMLStringChunks: [
+          "<div>foo</div>",
+          "<script>window.__executed = true</script>",
+        ],
+      });
+      const executed = await page.evaluate(
+        () => (window as any).__executed === true,
+      );
+
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div>foo</div>
+            <script>window.__executed = true</script>
+          </body>
+        </html>
+      `),
+      );
+      expect(executed).toBeFalse();
+    });
+
+    it("should NOT re-execute a pre-existing <script> with the same content", async () => {
+      const [newHTML] = await testDiff({
+        oldHTMLString: `<script>window.__count = (window.__count || 0) + 1</script><div>foo</div>`,
+        newHTMLStringChunks: [
+          "<script>window.__count = (window.__count || 0) + 1</script>",
+          "<div>bar</div>",
+        ],
+      });
+      const count = await page.evaluate(() => (window as any).__count);
+
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head>
+            <script>window.__count = (window.__count || 0) + 1</script>
+          </head>
+          <body>
+            <div>bar</div>
+          </body>
+        </html>
+      `),
+      );
+      // Executed exactly once (on initial page load), not again after diffing.
+      expect(count).toBe(1);
+    });
   });
 
   async function testDiff({
     oldHTMLString,
-    newHTMLStringChunks,
+    newHTMLStringChunks = [],
+    newHTMLByteChunks,
     useForEeachStreamNode = false,
     slowChunks = false,
     transition = false,
@@ -1778,7 +1913,11 @@ describe("Diff test", () => {
     onNextNode,
   }: {
     oldHTMLString: string;
-    newHTMLStringChunks: string[];
+    newHTMLStringChunks?: string[];
+    // Raw byte chunks (each an array of UTF-8 byte values) to test chunk
+    // boundaries that split multi-byte characters, which cannot be expressed
+    // as JS strings.
+    newHTMLByteChunks?: number[][];
     useForEeachStreamNode?: boolean;
     slowChunks?: boolean;
     transition?: boolean;
@@ -1791,6 +1930,7 @@ describe("Diff test", () => {
       async ([
         diffCode,
         newHTMLStringChunks,
+        newHTMLByteChunks,
         useForEeachStreamNode,
         slowChunks,
         transition,
@@ -1800,12 +1940,18 @@ describe("Diff test", () => {
       ]) => {
         eval(diffCode as string);
         const encoder = new TextEncoder();
+        const byteChunks = newHTMLByteChunks as number[][] | undefined;
+        const chunks = byteChunks ?? (newHTMLStringChunks as string[]);
         const readable = new ReadableStream({
           start: async (controller) => {
-            for (const chunk of newHTMLStringChunks as string[]) {
+            for (const chunk of chunks) {
               if (slowChunks)
                 await new Promise((resolve) => setTimeout(resolve, 100));
-              controller.enqueue(encoder.encode(chunk));
+              controller.enqueue(
+                byteChunks
+                  ? new Uint8Array(chunk as number[])
+                  : encoder.encode(chunk as string),
+              );
             }
             controller.close();
           },
@@ -1886,6 +2032,7 @@ describe("Diff test", () => {
       [
         diffCode,
         newHTMLStringChunks,
+        newHTMLByteChunks,
         useForEeachStreamNode,
         slowChunks,
         transition,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1924,6 +1924,115 @@ describe("Diff test", () => {
         }),
       ).rejects.toThrow("network dead");
     });
+
+    it("should apply children of an open last node progressively (main as last child)", async () => {
+      const [newHTML, , , , midStreamH1] = await testDiff({
+        oldHTMLString: `
+        <div class="layout">
+          <nav><a>nav</a></nav>
+          <main><article><h1>OLD</h1><p>para OLD</p><p>tail</p></article></main>
+        </div>
+      `,
+        newHTMLStringChunks: [
+          '<div class="layout"><nav><a>nav</a></nav><main><article><h1>NEW</h1><p>para NEW</p>',
+          "<p>tail</p></article></main></div>",
+        ],
+        midStreamEval: `document.querySelector('h1').textContent`,
+      });
+
+      // The <main> subtree must be diffed WHILE the stream is still open,
+      // even though <main> is the last child of a still-open container.
+      expect(midStreamH1).toBe("NEW");
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div class="layout">
+              <nav><a>nav</a></nav>
+              <main><article><h1>NEW</h1><p>para NEW</p><p>tail</p></article></main>
+            </div>
+          </body>
+        </html>
+      `),
+      );
+    });
+
+    it("should apply an open last node progressively and still ADD trailing siblings from a later chunk", async () => {
+      const [newHTML, , , , midStreamH1] = await testDiff({
+        oldHTMLString: `
+        <div class="layout">
+          <nav><a>nav</a></nav>
+          <main><article><h1>OLD</h1><p>tail</p></article></main>
+        </div>
+      `,
+        newHTMLStringChunks: [
+          '<div class="layout"><nav><a>nav</a></nav><main><article><h1>NEW</h1><p>tail</p>',
+          "</article></main><footer>bye</footer></div>",
+        ],
+        midStreamEval: `document.querySelector('h1').textContent`,
+      });
+
+      expect(midStreamH1).toBe("NEW");
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div class="layout">
+              <nav><a>nav</a></nav>
+              <main><article><h1>NEW</h1><p>tail</p></article></main>
+              <footer>bye</footer>
+            </div>
+          </body>
+        </html>
+      `),
+      );
+    });
+
+    it("should defer pruning of trailing old nodes until the open level is closed", async () => {
+      const [newHTML, , , , midStream] = await testDiff({
+        oldHTMLString: `
+        <div class="layout">
+          <nav><a>nav</a></nav>
+          <main><article><h1>OLD</h1><p>tail</p></article></main>
+          <footer>bye</footer>
+          <aside>ads</aside>
+        </div>
+      `,
+        newHTMLStringChunks: [
+          '<div class="layout"><nav><a>nav</a></nav><main><article><h1>NEW</h1><p>tail</p>',
+          "</article></main></div>",
+        ],
+        midStreamEval: `JSON.stringify({
+          h1: document.querySelector('h1').textContent,
+          footer: !!document.querySelector('footer'),
+          aside: !!document.querySelector('aside'),
+        })`,
+      });
+
+      // Mid-stream: the open subtree is already applied, but the trailing old
+      // nodes are NOT pruned yet — the level may still receive new children.
+      expect(JSON.parse(midStream)).toEqual({
+        h1: "NEW",
+        footer: true,
+        aside: true,
+      });
+      // Once the stream closes, the deferred pruning runs.
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div class="layout">
+              <nav><a>nav</a></nav>
+              <main><article><h1>NEW</h1><p>tail</p></article></main>
+            </div>
+          </body>
+        </html>
+      `),
+      );
+    });
   });
 
   async function testDiff({
@@ -1931,6 +2040,7 @@ describe("Diff test", () => {
     newHTMLStringChunks = [],
     newHTMLByteChunks,
     errorStreamMessage,
+    midStreamEval,
     useForEeachStreamNode = false,
     slowChunks = false,
     transition = false,
@@ -1947,20 +2057,24 @@ describe("Diff test", () => {
     // When set, the stream errors with this message after emitting all chunks
     // instead of closing (simulates an aborted fetch / dead network).
     errorStreamMessage?: string;
+    // JS expression evaluated in the page BEFORE enqueuing the last chunk
+    // (after a settle delay), to observe the mid-stream DOM state.
+    midStreamEval?: string;
     useForEeachStreamNode?: boolean;
     slowChunks?: boolean;
     transition?: boolean;
     ignoreId?: boolean;
     registerWC?: boolean;
     onNextNode?: string
-  }): Promise<[string, any[], Node[], boolean, string]> {
+  }): Promise<[string, any[], Node[], boolean, any, string]> {
     await page.setContent(normalize(oldHTMLString));
-    const [mutations, streamNodes, transitionApplied, logs] = await page.evaluate(
+    const [mutations, streamNodes, transitionApplied, midStreamResult, logs] = await page.evaluate(
       async ([
         diffCode,
         newHTMLStringChunks,
         newHTMLByteChunks,
         errorStreamMessage,
+        midStreamEval,
         useForEeachStreamNode,
         slowChunks,
         transition,
@@ -1972,11 +2086,19 @@ describe("Diff test", () => {
         const encoder = new TextEncoder();
         const byteChunks = newHTMLByteChunks as number[][] | undefined;
         const chunks = byteChunks ?? (newHTMLStringChunks as string[]);
+        let midStreamResult;
         const readable = new ReadableStream({
           start: async (controller) => {
-            for (const chunk of chunks) {
+            for (let i = 0; i < chunks.length; i++) {
               if (slowChunks)
                 await new Promise((resolve) => setTimeout(resolve, 100));
+              if (midStreamEval && i === chunks.length - 1) {
+                // Let the walker settle on the already-emitted chunks before
+                // observing the mid-stream DOM state.
+                await new Promise((resolve) => setTimeout(resolve, 500));
+                midStreamResult = eval(midStreamEval as string);
+              }
+              const chunk = chunks[i];
               controller.enqueue(
                 byteChunks
                   ? new Uint8Array(chunk as number[])
@@ -2065,13 +2187,14 @@ describe("Diff test", () => {
 
         observer.disconnect();
 
-        return [allMutations, streamNodes, transitionApplied, (window as any).logs];
+        return [allMutations, streamNodes, transitionApplied, midStreamResult, (window as any).logs];
       },
       [
         diffCode,
         newHTMLStringChunks,
         newHTMLByteChunks,
         errorStreamMessage,
+        midStreamEval,
         useForEeachStreamNode,
         slowChunks,
         transition,
@@ -2086,6 +2209,7 @@ describe("Diff test", () => {
       mutations,
       streamNodes,
       transitionApplied,
+      midStreamResult,
       logs
     ];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ type Walker = {
   [NEXT_SIBLING]: (node: Node) => Promise<Node | null>;
   [APPLY_TRANSITION]: (v: () => void) => void;
   [VISITED]: WeakSet<Node>;
+  [SETTLE]: (node: Node) => Promise<void>;
 };
 
 type NextNodeCallback = (node: Node) => void;
@@ -30,6 +31,7 @@ const APPLY_TRANSITION = 0;
 const FIRST_CHILD = 1;
 const NEXT_SIBLING = 2;
 const VISITED = 3;
+const SETTLE = 4;
 const SPECIAL_TAGS = new Set(["HTML", "HEAD", "BODY"]);
 const wait = () => new Promise((resolve) => requestAnimationFrame(resolve));
 
@@ -101,6 +103,7 @@ function settledWalker(walker: Walker, options: Options = {}): Walker {
     [NEXT_SIBLING]: hop("nextSibling"),
     [APPLY_TRANSITION]: (v) => v(),
     [VISITED]: walker[VISITED],
+    [SETTLE]: async () => {},
   };
 }
 
@@ -109,6 +112,7 @@ function settledWalker(walker: Walker, options: Options = {}): Walker {
  */
 async function updateNode(oldNode: Node, newNode: Node, walker: Walker) {
   if (oldNode.nodeType !== newNode.nodeType) {
+    await walker[SETTLE](newNode);
     markSubtree(newNode, walker[VISITED]);
 
     return walker[APPLY_TRANSITION](() =>
@@ -232,6 +236,7 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
       checkOld = oldNode;
       oldNode = oldNode.nextSibling;
       if (getKey(checkOld)) {
+        await walker[SETTLE](newNode);
         markSubtree(newNode, walker[VISITED]);
         insertedNode = newNode.cloneNode(true);
         walker[APPLY_TRANSITION](() =>
@@ -241,6 +246,7 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
         await updateNode(checkOld, newNode, walker);
       }
     } else {
+      await walker[SETTLE](newNode);
       markSubtree(newNode, walker[VISITED]);
       insertedNode = newNode.cloneNode(true);
       walker[APPLY_TRANSITION](() => oldParent.appendChild(insertedNode!));
@@ -320,12 +326,27 @@ async function htmlStreamWalker(
     return async (node: Node) => {
       if (!node) return null;
 
-      let nextNode = node[field];
+      const hop = () => {
+        let nextNode = node[field];
 
-      // Hop over ignored nodes by SIBLING: hopping by `field` would descend
-      // INTO an ignored first child instead of skipping it.
-      while (options.shouldIgnoreNode?.(nextNode)) {
-        nextNode = nextNode!.nextSibling;
+        // Hop over ignored nodes by SIBLING: hopping by `field` would descend
+        // INTO an ignored first child instead of skipping it.
+        while (options.shouldIgnoreNode?.(nextNode)) {
+          nextNode = nextNode!.nextSibling;
+        }
+
+        return nextNode;
+      };
+
+      let nextNode = hop();
+
+      // A null hop FROM the parser's frontier is not the end of the level:
+      // the parent is still open, so later chunks may still add nodes here.
+      // Waiting defers the pruning at the end of setChildNodes until the
+      // level is closed (or the stream ends/errors).
+      while (!nextNode && isLastNodeOfChunk(node)) {
+        await wait();
+        nextNode = hop();
       }
 
       if (nextNode) {
@@ -333,9 +354,11 @@ async function htmlStreamWalker(
         await options.onNextNode?.(nextNode);
       }
 
-      const waitChildren = field === "firstChild";
-
-      while (isLastNodeOfChunk(nextNode as Element, waitChildren)) {
+      // Wait only while the node is the parser's frontier AND has no children
+      // yet: a frontier node with children can already be diffed progressively
+      // (its own hops wait as needed), instead of stalling the whole subtree
+      // until the stream closes.
+      while (isLastNodeOfChunk(nextNode as Element, true)) {
         await wait();
       }
 
@@ -382,5 +405,14 @@ async function htmlStreamWalker(
       } else v();
     },
     [VISITED]: visited,
+    // Waits until the node stops being the parser's frontier (or the stream
+    // ends), so cloning it deeply cannot snapshot a half-parsed subtree.
+    [SETTLE]: async (node: Node) => {
+      while (isLastNodeOfChunk(node)) {
+        await wait();
+      }
+
+      if (streamError) throw streamError;
+    },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,29 +282,37 @@ async function htmlStreamWalker(
   const decoderStream = new TextDecoderStream();
   const decoderStreamReader = decoderStream.readable.getReader();
   let streamInProgress = true;
+  let streamError: Error | undefined;
 
-  stream.pipeTo(decoderStream.writable);
+  // The error already surfaces through the reader in processStream; this
+  // only silences the duplicated unhandled rejection.
+  stream.pipeTo(decoderStream.writable).catch(() => {});
   processStream();
 
   async function processStream() {
     try {
       while (true) {
         const { done, value } = await decoderStreamReader.read();
-        if (done) {
-          streamInProgress = false;
-          break;
-        }
+        if (done) break;
 
         doc.write(value);
       }
+    } catch (error) {
+      streamError = error as Error;
     } finally {
+      streamInProgress = false;
       doc.close();
     }
   }
 
-  while (!doc.documentElement || isLastNodeOfChunk(doc.documentElement)) {
+  while (
+    !streamError &&
+    (!doc.documentElement || isLastNodeOfChunk(doc.documentElement))
+  ) {
     await wait();
   }
+
+  if (streamError) throw streamError;
 
   const visited = new WeakSet<Node>();
 
@@ -330,6 +338,8 @@ async function htmlStreamWalker(
       while (isLastNodeOfChunk(nextNode as Element, waitChildren)) {
         await wait();
       }
+
+      if (streamError) throw streamError;
 
       return nextNode;
     };


### PR DESCRIPTION
## What

Two walker fixes plus a test hardening pass for arbitrary chunk boundaries. Version bumped to **0.6.8** (\`deno.json\` was stale at 0.6.6 and is now synced).

### Fix 1 — the body was never applied progressively when content hangs off the last child

In the \`nextSibling\` hop, \`isLastNodeOfChunk\` fell through to \`return streamInProgress\` — an unconditional wait — even when the open node already had complete children to diff. Since real pages hang their content off the last child of a container (\`<main>\` after \`<nav>\`), the walk stalled before entering it and **nothing of the body was applied until the stream closed**; only the \`<head>\` (which precedes it) streamed. Measured on a real docs site: during a 3s mid-stream pause, 43 mutations — all in \`<head>\`, zero in the body.

The fix descends into an open last node once it has children (same condition the \`firstChild\` hop already used), and defers the **pruning** phase of \`setChildNodes\` for a level whose parent is still open — trailing nodes may yet arrive in a later chunk, so removing them early would corrupt the page. Deep clones settle before cloning so a half-parsed subtree is never photographed.

### Fix 2 — an erroring stream hung \`diff()\` forever

\`processStream()\` only cleared \`streamInProgress\` on the \`done\` path. A stream that *errors* (an aborted fetch, a dropped connection) left it \`true\`, so the walker waited on \`requestAnimationFrame\` indefinitely: \`diff()\` neither resolved nor rejected, plus unhandled rejections from the fire-and-forget reader and \`pipeTo\`. For a SPA router this meant one aborted navigation froze all navigation until a hard reload.

Now the error is captured, \`streamInProgress\` clears in \`finally\`, the duplicate \`pipeTo\` rejection is silenced, and **\`diff()\` rejects with the stream's error** in bounded time.

### Tests

TDD throughout — every fix landed with a failing test first. New coverage (ran on Chromium, Firefox and WebKit; 137 pass):

- tag names, attribute names and attribute values split across chunks
- multi-byte UTF-8 characters split at byte level across chunks
- \`<script>\` semantics pinned: a NEW streamed inline script is inserted but **not** executed (parsed in the inert document, the "already started" flag survives cloning — identical in all three engines); a pre-existing script is not re-executed
- stream error before/after the first chunk → \`diff()\` rejects
- progressive body: \`h1\` inside \`<main>\`-as-last-child updates **mid-stream**; trailing siblings added or removed by a later chunk reconcile correctly once the level closes

Harness additions: \`newHTMLByteChunks\` (raw byte chunks), \`errorStreamMessage\`, \`midStreamEval\` (DOM snapshot during the pause before the last chunk).

## Why now

The Janux framework moved to streamed SSR (flushing many small chunks with boundaries anywhere) and its SPA navigation aborts superseded page streams — both fixes are prerequisites for that to work, and the chunk-boundary tests pin the contract it relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)