### PR TITLE
fix: do not deadlock when the diff runs inside a view transition

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,6 +96,58 @@ describe("Diff test", () => {
       );
       expect(transitionApplied).toBeTrue();
     });
+
+    /**
+     * A router wrapping the whole swap in one transition, rather than letting
+     * `transition: true` start one per DOM update — the only way shared
+     * `view-transition-name` elements are paired across a full page change.
+     *
+     * A view transition suppresses rendering until its update callback
+     * resolves, so `requestAnimationFrame` never fires inside one. Settling the
+     * stream on rAF alone therefore deadlocks the walk until the browser aborts
+     * the transition on its 4s DOM-update timeout: the page freezes for four
+     * seconds and then swaps with no animation at all.
+     */
+    it("should complete a diff that runs inside document.startViewTransition", async () => {
+      await page.setContent(normalize(`<div><h1>hello world</h1></div>`));
+
+      const result = await page.evaluate(async (code) => {
+        eval(code as string);
+        const encoder = new TextEncoder();
+        const readable = new ReadableStream({
+          start(controller) {
+            for (const chunk of ["<div>", "<h1>hello world!</h1>", "</div>"]) {
+              controller.enqueue(encoder.encode(chunk));
+            }
+            controller.close();
+          },
+        });
+        const startedAt = performance.now();
+        // @ts-ignore
+        const transition = document.startViewTransition(() =>
+          // @ts-ignore
+          diff(document.documentElement!, readable),
+        );
+
+        transition.finished.catch(() => {});
+        await transition.updateCallbackDone;
+
+        return {
+          elapsed: performance.now() - startedAt,
+          ready: await transition.ready.then(
+            () => "resolved",
+            (error: any) => `rejected: ${error?.name}`,
+          ),
+          heading: document.querySelector("h1")?.textContent,
+        };
+      }, diffCode);
+
+      expect(result.heading).toBe("hello world!");
+      // Not aborted: a timed-out transition applies the DOM change but never animates.
+      expect(result.ready).toBe("resolved");
+      // The deadlock ended at Chrome's 4s cap; a working swap is milliseconds.
+      expect(result.elapsed).toBeLessThan(2000);
+    });
   });
 
   describe.each(["chrome", "firefox", "safari"])("%s", (browserName) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,24 @@ const NEXT_SIBLING = 2;
 const VISITED = 3;
 const SETTLE = 4;
 const SPECIAL_TAGS = new Set(["HTML", "HEAD", "BODY"]);
-const wait = () => new Promise((resolve) => requestAnimationFrame(resolve));
+
+/**
+ * A frame — or a timer, when frames are not coming.
+ *
+ * `requestAnimationFrame` does not fire while the document is
+ * rendering-suppressed, which is exactly what the View Transition API does to
+ * it while an update callback runs. A caller that wraps a whole diff in
+ * `document.startViewTransition` (the only way to pair shared
+ * `view-transition-name` elements across a full page change) would otherwise
+ * deadlock here until the browser abandons the transition on its DOM-update
+ * timeout: the page freezes for seconds and then swaps with no animation.
+ *
+ * Racing a timer against the frame fixes that without changing the normal
+ * path — outside a transition the frame arrives first — and it also keeps the
+ * walk moving in a background tab, where frames are throttled away too.
+ */
+const wait = () =>
+  new Promise((resolve) => (requestAnimationFrame(resolve), setTimeout(resolve, 16)));
 
 export default async function diff(
   oldNode: Node,


### PR DESCRIPTION
## The bug

`wait()` settled the stream walk on `requestAnimationFrame` alone:

```js
const wait = () => new Promise((resolve) => requestAnimationFrame(resolve));
```

rAF does not fire while a document is **rendering-suppressed**, and that is exactly what the View Transition API does to it for the whole duration of an update callback. Verified in Chrome:

```
callback entered
rAF did NOT fire within 1500ms (+1509ms)
microtask ok
setTimeout fired (+1519ms)
```

So a caller that wraps the whole diff in `document.startViewTransition` deadlocks here until the browser abandons the transition on its 4-second DOM-update timeout — the page freezes for four seconds and then swaps with **no animation at all**:

```
start
ready REJECTED: TimeoutError: Transition was aborted because of timeout in DOM update
updateDone +4009ms
finished +4009ms
```

This is not an exotic call pattern: it is the one this README already documents under [_Incremental vs full transition_](README.md#incremental-vs-full-transition), and it is the only way to pair shared `view-transition-name` elements across a full page change. `transition: true` cannot do it — it starts one transition per DOM update and each new one skips the previous, so on a real page swap I measured **51 transitions started, 50 skipped, 1 animated**: the page snaps through and only the last fragment fades.

## The fix

Race a timer against the frame. Outside a transition the frame still arrives first, so the normal path is unchanged; inside one the timer is the only thing that fires. It also keeps the walk moving in a background tab, where frames are throttled away for the same reason.

```diff
-const wait = () => new Promise((resolve) => requestAnimationFrame(resolve));
+const wait = () =>
+  new Promise((resolve) => (requestAnimationFrame(resolve), setTimeout(resolve, 16)));
```

After, same page swap:

```
start
updateDone +23ms
ready +24ms
finished +282ms
```

One transition, the diff completing in 23 ms inside the callback, and a real 282 ms animation.

## Test

`should complete a diff that runs inside document.startViewTransition` — runs a real diff inside a real `startViewTransition` and asserts the DOM updated, `ready` **resolved** (a timed-out transition still applies the change, so asserting only the DOM would pass on the bug), and the callback finished well inside the 4 s cap.

Red before the fix, green after:

| | result |
|---|---|
| before | ✗ `expected "resolved", received "rejected: TimeoutError"` — 4137 ms |
| after | ✓ 643 ms |

Full suite: **138 pass, 0 fail** across Chrome, Firefox and Safari.

## One thing to decide: the bundle budget

The fix costs **15 bytes gzipped** (1479 → 1494) against a `bundlewatch` `maxSize` of `1.5 kB`, so it passes with **6 bytes of headroom**. That is tight enough that the next change is likely to trip it. Worth bumping `maxSize` to `1.6 kB` in the same PR if you agree — say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)