### PR TITLE
fix: an ignored node is never pruned, moved or rewritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ type Options = {
   onNextNode?: NextNodeCallback;
   // update the DOM using document.startViewTransition (default: false)
   transition?: boolean;
-  // callback to ignore nodes (default: undefined)
+  // callback to leave nodes alone, on both the old and the new tree: an
+  // ignored node is never updated, moved or removed, and never counts as one
+  // of the old children the diff has to prune (default: undefined)
   shouldIgnoreNode?: (node: Node | null) => boolean;
 };
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "files": [
       {
         "path": "./build/index.js",
-        "maxSize": "1.5 kB"
+        "maxSize": "1.6 kB"
       }
     ]
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1680,12 +1680,14 @@ describe("Diff test", () => {
         ],
         ignoreId: true,
       });
+      // Ignored means untouched: the node keeps its own content ("bar", not the
+      // incoming "bazz!") and stays put, while its siblings diff as usual.
       expect(newHTML).toBe(
         normalize(`
         <html>
           <head></head>
           <body>
-              <div>bar</div>
+              <div>bar<div id="ignore">bar</div></div>
           </body>
         </html>
     `),
@@ -1710,7 +1712,36 @@ describe("Diff test", () => {
         <html>
           <head></head>
           <body>
-            <div><b>new</b></div>
+            <div><span id="ignore">skip</span><b>new</b></div>
+          </body>
+        </html>
+    `),
+      );
+    });
+
+    it("should options.shouldIgnoreNode keep an ignored node the incoming page does not list", async () => {
+      // The reason the option exists: a stylesheet injected at runtime (a lazy
+      // editor's CSS, a dev server's <style>) lives only in the live document,
+      // so the incoming page is always one node shorter. Counting it made the
+      // tail removal take it, and re-attaching a detached stylesheet leaves it
+      // pending — the page paints unstyled for a frame.
+      const [newHTML] = await testDiff({
+        oldHTMLString: `
+        <div>
+          <b>old</b>
+          <span id="ignore">injected</span>
+        </div>
+      `,
+        newHTMLStringChunks: ["<html><head></head><body><div><b>new</b></div></body></html>"],
+        ignoreId: true,
+      });
+
+      expect(newHTML).toBe(
+        normalize(`
+        <html>
+          <head></head>
+          <body>
+            <div><b>new</b><span id="ignore">injected</span></div>
           </body>
         </html>
     `),

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ type Walker = {
   [APPLY_TRANSITION]: (v: () => void) => void;
   [VISITED]: WeakSet<Node>;
   [SETTLE]: (node: Node) => Promise<void>;
+  [IGNORED]: (node: Node | null) => boolean;
 };
 
 type NextNodeCallback = (node: Node) => void;
@@ -28,6 +29,7 @@ const FIRST_CHILD = 1;
 const NEXT_SIBLING = 2;
 const VISITED = 3;
 const SETTLE = 4;
+const IGNORED = 5;
 const SPECIAL_TAGS = new Set(["HTML", "HEAD", "BODY"]);
 
 /**
@@ -117,6 +119,7 @@ function settledWalker(walker: Walker, options: Options = {}): Walker {
     [APPLY_TRANSITION]: (v) => v(),
     [VISITED]: walker[VISITED],
     [SETTLE]: async () => {},
+    [IGNORED]: walker[IGNORED],
   };
 }
 
@@ -213,10 +216,13 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
 
   // Extract keyed nodes from previous children and keep track of total count.
   while (oldNode) {
-    extra++;
     checkOld = oldNode;
-    oldKey = getKey(checkOld);
     oldNode = oldNode.nextSibling;
+    // An ignored node is not the diff's to account for: counting it inflates
+    // `extra`, and the tail removal below then takes one node too many.
+    if (walker[IGNORED](checkOld)) continue;
+    extra++;
+    oldKey = getKey(checkOld);
 
     if (oldKey) {
       if (!keyedNodes) keyedNodes = {};
@@ -224,7 +230,16 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
     }
   }
 
-  oldNode = oldParent.firstChild;
+  // Ignored nodes are invisible to the walk as well as to the removal: matched
+  // against an incoming node they would be rewritten into it, which is the one
+  // thing the caller asked not to happen.
+  const nextOwn = (node: ChildNode | null) => {
+    while (node && walker[IGNORED](node)) node = node.nextSibling;
+
+    return node;
+  };
+
+  oldNode = nextOwn(oldParent.firstChild);
 
   // Loop over new nodes and perform updates.
   while (newNode) {
@@ -241,13 +256,13 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
           oldParent.insertBefore(foundNode!, oldNode),
         );
       } else {
-        oldNode = oldNode.nextSibling;
+        oldNode = nextOwn(oldNode.nextSibling);
       }
 
       await updateNode(foundNode, newNode, walker);
     } else if (oldNode) {
       checkOld = oldNode;
-      oldNode = oldNode.nextSibling;
+      oldNode = nextOwn(oldNode.nextSibling);
       if (getKey(checkOld)) {
         await walker[SETTLE](newNode);
         markSubtree(newNode, walker[VISITED]);
@@ -279,8 +294,20 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
       oldParent.removeChild(keyedNodes![oldKey]!);
     }
 
-    // If we have any remaining unkeyed nodes remove them from the end.
-    while (--extra >= 0) oldParent.removeChild(oldParent.lastChild!);
+    // If we have any remaining unkeyed nodes remove them from the end,
+    // stepping over the ignored ones: a runtime-injected `<style>` sitting at
+    // the end of `<head>` is exactly what `shouldIgnoreNode` is asked to
+    // protect, and detaching it makes the page paint unstyled.
+    let last = oldParent.lastChild;
+
+    while (--extra >= 0) {
+      while (last && walker[IGNORED](last)) last = last.previousSibling;
+      if (!last) break;
+      const doomed = last;
+
+      last = last.previousSibling;
+      oldParent.removeChild(doomed);
+    }
   });
 }
 
@@ -418,6 +445,7 @@ async function htmlStreamWalker(
       } else v();
     },
     [VISITED]: visited,
+    [IGNORED]: (node) => !!options.shouldIgnoreNode?.(node),
     // Waits until the node stops being the parser's frontier (or the stream
     // ends), so cloning it deeply cannot snapshot a half-parsed subtree.
     [SETTLE]: async (node: Node) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ type Walker = {
   [APPLY_TRANSITION]: (v: () => void) => void;
   [VISITED]: WeakSet<Node>;
   [SETTLE]: (node: Node) => Promise<void>;
-  [IGNORED]: (node: Node | null) => boolean;
+  [IGNORED]: (node: Node | null) => unknown;
 };
 
 type NextNodeCallback = (node: Node) => void;
@@ -113,13 +113,11 @@ function settledWalker(walker: Walker, options: Options = {}): Walker {
   };
 
   return {
-    root: walker.root,
+    ...walker,
     [FIRST_CHILD]: hop("firstChild"),
     [NEXT_SIBLING]: hop("nextSibling"),
     [APPLY_TRANSITION]: (v) => v(),
-    [VISITED]: walker[VISITED],
     [SETTLE]: async () => {},
-    [IGNORED]: walker[IGNORED],
   };
 }
 
@@ -298,14 +296,11 @@ async function setChildNodes(oldParent: Node, newParent: Node, walker: Walker) {
     // stepping over the ignored ones: a runtime-injected `<style>` sitting at
     // the end of `<head>` is exactly what `shouldIgnoreNode` is asked to
     // protect, and detaching it makes the page paint unstyled.
-    let last = oldParent.lastChild;
-
     while (--extra >= 0) {
-      while (last && walker[IGNORED](last)) last = last.previousSibling;
-      if (!last) break;
-      const doomed = last;
+      let doomed = oldParent.lastChild;
 
-      last = last.previousSibling;
+      while (doomed && walker[IGNORED](doomed)) doomed = doomed.previousSibling;
+      if (!doomed) break;
       oldParent.removeChild(doomed);
     }
   });
@@ -445,7 +440,7 @@ async function htmlStreamWalker(
       } else v();
     },
     [VISITED]: visited,
-    [IGNORED]: (node) => !!options.shouldIgnoreNode?.(node),
+    [IGNORED]: (node) => options.shouldIgnoreNode?.(node),
     // Waits until the node stops being the parser's frontier (or the stream
     // ends), so cloning it deeply cannot snapshot a half-parsed subtree.
     [SETTLE]: async (node: Node) => {


### PR DESCRIPTION
`shouldIgnoreNode` only made the walk hop over a node. Everything else still treated it as an ordinary child:

- it was **counted** among the old children, so `extra` was too high and the tail removal took one node too many;
- the removal itself was `removeChild(oldParent.lastChild)`, which never consulted the predicate;
- and it could be **matched against an incoming node and rewritten into it**, which is the one thing a caller asking to ignore it cannot want.

### The case that surfaced it

A page whose `<head>` holds runtime-injected stylesheets — a lazily loaded editor's CSS, a dev server's `<style>` tags — that the incoming page never lists. Measured on a real navigation (Janux docs, playground → docs): **55 applied stylesheets down to 0** mid-swap, then restored a beat later by the app. That round trip *is* a flash of unstyled content, because a re-attached stylesheet is a new, pending one and the browser paints without it until it resolves.

Protecting those nodes with `shouldIgnoreNode` did nothing, because the prune never looked.

### The fix

The predicate is now honoured in the three places that touch old children: the count, the walk, and the removal. Ignored means untouched, in place — its content, its position and its identity all survive, while its siblings diff as usual.

### Contract change

The two existing `shouldIgnoreNode` tests asserted that an ignored node ended up **deleted**, which is the opposite of what the option is named for and of what the README describes. Their expectations now pin the node surviving with its own content. A third row covers the case above: an ignored node the incoming page does not list is kept rather than pruned.

If anyone was relying on "ignored ⇒ removed", that was accidental, and there is no way to express "leave this alone" without it.

### Size

The library's whole point is being tiny, so: **1494 → 1570 bytes gzip (+76 B)**, raw 3386 → 3603. The cost is almost entirely the walk-side skip, which is what prevents an ignored node from being rewritten; the count and prune changes are a few bytes.

### Tests

`bun test` → **141 pass, 0 fail** across chrome, firefox and safari (was 138). The 132 unrelated tests are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
